### PR TITLE
Adds namespace to android/build.gralde file

### DIFF
--- a/flutter_document_scanner_android/CHANGELOG.md
+++ b/flutter_document_scanner_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.1
+* Adds compatibility with Android Gradle Plugin 8.0, by adding a namespace to the build.gradle.
+
 ## 1.1.0
 * Upgrade Android SDK to 33, gradle to 7.3.0 and kotlin to 1.8.20
 

--- a/flutter_document_scanner_android/android/build.gradle
+++ b/flutter_document_scanner_android/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace("com.christian.flutterDocumentScanner")
+    }
+
     compileSdkVersion 33
 
     compileOptions {

--- a/flutter_document_scanner_android/pubspec.yaml
+++ b/flutter_document_scanner_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_document_scanner_android
 description: Android implementation of the flutter_document_scanner plugin
 repository: https://github.com/criistian14/flutter_document_scanner/tree/master/flutter_document_scanner_android
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/flutter_document_scanner_android/pubspec.yaml
+++ b/flutter_document_scanner_android/pubspec.yaml
@@ -19,8 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_document_scanner_platform_interface:
-    path: ../flutter_document_scanner_platform_interface
+  flutter_document_scanner_platform_interface: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Adds a namespace to the `android/build.gradle` file so the project is compatible with AGP 8 and higher. 

Since the current version is missing the namespace it causes an error when the plugin is being used in projects that already migrated to AGP 8 or higher.

Error details:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':flutter_document_scanner_android'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.
```

The added `if (project.android.hasProperty("namespace"))` statement ensures the plugin will remain backwards compatible with older AGP versions.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
